### PR TITLE
Add volume booster functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Volume Booster Chrome Extension
+
+This extension allows you to boost the audio volume of any tab up to 600%. It uses the Web Audio API to apply a gain node to all audio and video elements on the page.
+
+## Development
+
+Install dependencies and build the extension:
+
+```bash
+npm install
+npm run build
+```
+
+The compiled extension will be in the `dist/` directory. Load that folder in Chrome as an unpacked extension.

--- a/dist/background.js
+++ b/dist/background.js
@@ -1,4 +1,4 @@
 "use strict";
 chrome.runtime.onInstalled.addListener(() => {
-    console.log("Volume Master TS installed");
+    console.log("Volume Booster installed");
 });

--- a/dist/content.js
+++ b/dist/content.js
@@ -1,11 +1,27 @@
 "use strict";
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+const gainNodes = new WeakMap();
+const contexts = new WeakMap();
+function ensureGain(el) {
+    let gain = gainNodes.get(el);
+    if (!gain) {
+        const ctx = new AudioContext();
+        const source = ctx.createMediaElementSource(el);
+        gain = ctx.createGain();
+        source.connect(gain);
+        gain.connect(ctx.destination);
+        ctx.resume();
+        contexts.set(el, ctx);
+        gainNodes.set(el, gain);
+    }
+    return gain;
+}
+chrome.runtime.onMessage.addListener((msg) => {
     if (msg.action === "set_volume") {
-        // Set all audio/video elements' volume
-        const volume = Math.max(0, Math.min(6, msg.value)); // Clamp 0-6
-        document.querySelectorAll("audio,video").forEach((el) => {
-            el.volume = Math.min(1, volume); // Browsers only allow 0-1 for volume
-            // If you want >100%, you'd need to use "gain" via Web Audio API (advanced)
+        const volume = Math.max(0, Math.min(6, msg.value));
+        document.querySelectorAll("audio,video").forEach((node) => {
+            const el = node;
+            const gain = ensureGain(el);
+            gain.gain.value = volume;
         });
     }
 });

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,31 +1,21 @@
 {
-    "manifest_version": 3,
-    "name": "Volume Master TS",
-    "version": "1.0",
-    "description": "Control tab audio volume.",
-    "permissions": [
-        "tabs",
-        "scripting",
-        "activeTab"
-    ],
-    "host_permissions": [
-        "<all_urls>"
-    ],
-    "background": {
-        "service_worker": "background.js"
-    },
-    "action": {
-        "default_popup": "popup.html",
-        "default_icon": "favicon.ico"
-    },
-    "content_scripts": [
-        {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": [
-                "content.js"
-            ]
-        }
-    ]
+  "manifest_version": 3,
+  "name": "Volume Booster",
+  "version": "1.0",
+  "description": "Boost tab audio volume up to 600%.",
+  "permissions": ["tabs", "scripting", "activeTab"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": "favicon.ico"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "my_chrome_extension",
+  "name": "volume-booster-extension",
   "version": "1.0.0",
-  "description": "",
+  "description": "Chrome extension to boost tab audio volume using Web Audio API",
   "main": "index.js",
   "scripts": {
     "clean": "rimraf dist",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,31 +1,21 @@
 {
-    "manifest_version": 3,
-    "name": "Volume Master TS",
-    "version": "1.0",
-    "description": "Control tab audio volume.",
-    "permissions": [
-        "tabs",
-        "scripting",
-        "activeTab"
-    ],
-    "host_permissions": [
-        "<all_urls>"
-    ],
-    "background": {
-        "service_worker": "background.js"
-    },
-    "action": {
-        "default_popup": "popup.html",
-        "default_icon": "favicon.ico"
-    },
-    "content_scripts": [
-        {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": [
-                "content.js"
-            ]
-        }
-    ]
+  "manifest_version": 3,
+  "name": "Volume Booster",
+  "version": "1.0",
+  "description": "Boost tab audio volume up to 600%.",
+  "permissions": ["tabs", "scripting", "activeTab"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": "favicon.ico"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ]
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,3 @@
 chrome.runtime.onInstalled.addListener(() => {
-  console.log("Volume Master TS installed");
+  console.log("Volume Booster installed");
 });

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,10 +1,28 @@
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+const gainNodes = new WeakMap<HTMLMediaElement, GainNode>();
+const contexts = new WeakMap<HTMLMediaElement, AudioContext>();
+
+function ensureGain(el: HTMLMediaElement): GainNode {
+  let gain = gainNodes.get(el);
+  if (!gain) {
+    const ctx = new AudioContext();
+    const source = ctx.createMediaElementSource(el);
+    gain = ctx.createGain();
+    source.connect(gain);
+    gain.connect(ctx.destination);
+    ctx.resume();
+    contexts.set(el, ctx);
+    gainNodes.set(el, gain);
+  }
+  return gain;
+}
+
+chrome.runtime.onMessage.addListener((msg) => {
   if (msg.action === "set_volume") {
-    // Set all audio/video elements' volume
-    const volume = Math.max(0, Math.min(6, msg.value)); // Clamp 0-6
-    document.querySelectorAll("audio,video").forEach((el) => {
-      (el as HTMLMediaElement).volume = Math.min(1, volume); // Browsers only allow 0-1 for volume
-      // If you want >100%, you'd need to use "gain" via Web Audio API (advanced)
+    const volume = Math.max(0, Math.min(6, msg.value));
+    document.querySelectorAll("audio,video").forEach((node) => {
+      const el = node as HTMLMediaElement;
+      const gain = ensureGain(el);
+      gain.gain.value = volume;
     });
   }
 });


### PR DESCRIPTION
## Summary
- implement Web Audio API gain node to allow boosting audio volume in content script
- update background log and extension metadata to 'Volume Booster'
- add documentation with build instructions
- update package name
- rebuild dist

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f78d1bfe88326a06b622727b9e2bf