### PR TITLE
Keep extension volume boost after site changes

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -38,6 +38,10 @@ function ensureNodes(el: HTMLMediaElement): AudioNodes {
 
     nodes = { ctx, gain, bass, voice };
     nodesMap.set(el, nodes);
+
+    el.addEventListener("volumechange", () => {
+      nodes!.gain.gain.value = currentVolume;
+    });
   }
   return nodes;
 }


### PR DESCRIPTION
## Summary
- keep custom gain when sites change `<audio>` or `<video>` volume

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f9bdd9e5c83269242e5f4ac9fecfd