### PR TITLE
Keep extension volume boost after site changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 /__tests__
 jest.config.js
 jest.setup.js
+/dist
+

--- a/src/content.ts
+++ b/src/content.ts
@@ -38,6 +38,10 @@ function ensureNodes(el: HTMLMediaElement): AudioNodes {
 
     nodes = { ctx, gain, bass, voice };
     nodesMap.set(el, nodes);
+
+    el.addEventListener("volumechange", () => {
+      nodes!.gain.gain.value = currentVolume;
+    });
   }
   return nodes;
 }
@@ -67,7 +71,7 @@ const observer = new MutationObserver((mutations) => {
 
 observer.observe(document.documentElement, { childList: true, subtree: true });
 
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.action === "set_volume") {
     currentVolume = Math.max(0, Math.min(6, msg.value));
     applyToAll();
@@ -77,5 +81,8 @@ chrome.runtime.onMessage.addListener((msg) => {
   } else if (msg.action === "toggle_voice") {
     voiceEnabled = Boolean(msg.value);
     applyToAll();
+  } else if (msg.action === "get_volume") {
+    sendResponse({ value: currentVolume });
   }
+  return true;
 });


### PR DESCRIPTION
## Summary
- keep custom gain when sites change `<audio>` or `<video>` volume
- restore slider value using `get_volume` message
- ignore build output in `.gitignore`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f9bdd9e5c83269242e5f4ac9fecfd