### PR TITLE
Fix volume slider persistence

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -55,7 +55,12 @@ function applyToAll() {
   });
 }
 
-applyToAll();
+chrome.storage.local.get("boostVolume", (data) => {
+  if (typeof data.boostVolume === "number") {
+    currentVolume = data.boostVolume;
+  }
+  applyToAll();
+});
 
 const observer = new MutationObserver((mutations) => {
   for (const m of mutations) {
@@ -74,6 +79,7 @@ observer.observe(document.documentElement, { childList: true, subtree: true });
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.action === "set_volume") {
     currentVolume = Math.max(0, Math.min(6, msg.value));
+    chrome.storage.local.set({ boostVolume: currentVolume });
     applyToAll();
   } else if (msg.action === "toggle_bass") {
     bassEnabled = Boolean(msg.value);


### PR DESCRIPTION
## Summary
- load saved gain value from `chrome.storage.local` in content script
- persist new gain levels when the slider changes
- fall back to the stored boost value in the popup

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fa139363c8326abf4e1482d26b9e3